### PR TITLE
Builds shared libs for linux, static for mac

### DIFF
--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -1,7 +1,10 @@
+# build the shared libraries on linux
+set(BUILD_SHARED_LIBS ON)
 ## OSX/homebrew version of root6 installs its cmake macros in a non-standard
 ## location. This might be an issue on other systems as well.
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{ROOTSYS}/etc/root/cmake)
+  set(BUILD_SHARED_LIBS OFF)
 endif()
 
 ## Get rid of rpath warning on OSX

--- a/hana_decode/CMakeLists.txt
+++ b/hana_decode/CMakeLists.txt
@@ -46,7 +46,7 @@ set(PCM_FILE  ${CMAKE_CURRENT_BINARY_DIR}/haDecodeDict_rdict.pcm)
 
 ADD_CUSTOM_TARGET(haDecode_ROOTDICTS DEPENDS ${haDecode_src} ${headers} haDecode_LinkDef.h haDecodeDict.cxx)
 
-add_library(dc STATIC
+add_library(dc 
   ${haDecode_src}
   haDecodeDict.cxx
   )
@@ -66,11 +66,9 @@ target_include_directories(dc
 #target_compile_options( dc PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wall>)
 
 target_link_libraries(dc
-  #PUBLIC ${EXPAT_LIBRARIES}
-  #PUBLIC ${CMAKE_THREAD_LIBS_INIT}
   PUBLIC ${ROOT_LIBRARIES} 
   PUBLIC EVIO::EVIO
-  PRIVATE PODD::HallA
+  #PRIVATE PODD::HallA
 )
 #include(GNUInstallDirs)
 #set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/JSONUtils)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,7 +84,7 @@ include_directories(${PROJECT_SOURCE_DIR}/hana_decode)
 
 ADD_CUSTOM_TARGET(HallA_ROOTDICTS DEPENDS ${podd_src} ${headers} HallA_LinkDef.h HallADict.cxx)
 
-add_library(HallA STATIC
+add_library(HallA
   ${podd_src} HallADict.cxx
   )
 
@@ -104,8 +104,6 @@ target_include_directories(HallA
 #target_compile_features(HallA PRIVATE cxx_auto_type)
 
 target_link_libraries(HallA
-  #PUBLIC ${EXPAT_LIBRARIES}
-  #PUBLIC ${CMAKE_THREAD_LIBS_INIT}
   PUBLIC ${ROOT_LIBRARIES} 
   PRIVATE PODD::Decode 
 )


### PR DESCRIPTION
Removing the explicit shared/static and using BUILD_SHARED_LIBS to control type instead. See cmake/os.cmake.